### PR TITLE
Forward gulp-svgicons2svgfont’s glyph event to gulp-iconfont

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,11 @@ function gulpFontIcon(options) {
     duplex.emit('codepoints', codepoints, options);
   });
 
+  // Re-emit glyph mapping event
+  inStream.on('glyph', function(glyph) {
+    duplex.emit('glyph', glyph, options);
+  });
+
   return duplex;
 }
 


### PR DESCRIPTION
Is needed if wanting to set explicit settings on a glyph such as adding `ligatures`.