### PR TITLE
remove reference to deprecated plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,7 @@ gulp.task('Iconfont', function(){
 
 ### Make your CSS
 
-To use this font in your CSS, you could add a mixin like in this
- [real world example](https://github.com/ChtiJS/chtijs.francejs.org/blob/master/documents/less/_icons.less).
- You can also generate your CSS automatically with
- [`gulp-iconfont-scss`](https://github.com/backflip/gulp-iconfont-css).
- 
-It's also easy to make a CSS template by yourself. Like
+It's easy to make a CSS template by yourself. Like
  [this example](https://github.com/cognitom/symbols-for-sketch/blob/master/gulpfile.js#L17),
  `gulp-consolidate` is useful to handling
  [such a template](https://github.com/cognitom/symbols-for-sketch/blob/master/templates/fontawesome-style.css).


### PR DESCRIPTION
it's easy to miss you can create css files directly from this plugin and the plugin referenced is deprecated.

see: https://github.com/backflip/gulp-iconfont-css/issues/23
