### PR TITLE
Set the important texts to bold

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ And the [gulp-svg2ttf](https://github.com/nfroidure/gulp-svg2ttf#svg2ttfoptions)
 
 ## Preparing SVG's
 
-Beware that your SVG icons must have a high enough height. 500 is a minimum. If
+Beware that your SVG icons must have a high enough height. **500 is a minimum**. If
  you do not want to resize them, you can try to combine the `fontHeight` and
  the `normalize` option to get them in a correct size.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ gulp.task('Iconfont', function(){
  (`gulp-svgicons2svgfont`, `gulp-svg2tff`, `gulp-ttf2eot`, `gulp-ttf2woff`)
  for more flexibility, feel free to use them separately.
 
- If some font glyphs aren't converted properly you should add the
+ **If some font glyphs aren't converted properly** you should add the
   `normalize:true` option and a `fontHeight` greater than 1000
   (`fontHeight: 1001`).
 


### PR DESCRIPTION
Due to this https://github.com/nfroidure/gulp-iconfont/issues/105#issuecomment-185463174 It might be better to set it to bold.