### PR TITLE
Feature/make options available for svg2ttf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,14 +17,13 @@ function gulpFontIcon(options) {
 
   options = options || {};
   options.formats = options.formats || ['ttf', 'eot', 'woff'];
+  options.clone = -1 !== options.formats.indexOf('svg');
+  options.timestamp = options.timestamp || Date.now();
   // Generating SVG font and saving her
   inStream = svgicons2svgfont(options);
   // Generating TTF font and saving her
   outStream = inStream
-    .pipe(svg2ttf({
-      clone: -1 !== options.formats.indexOf('svg'),
-      timestamp: options.timestamp,
-    }).on('error', (err) => {
+    .pipe(svg2ttf(options).on('error', (err) => {
       outStream.emit('error', err);
     }))
     // TTFAutoHint

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function gulpFontIcon(options) {
   options = options || {};
   options.formats = options.formats || ['ttf', 'eot', 'woff'];
   options.clone = -1 !== options.formats.indexOf('svg');
-  options.timestamp = options.timestamp || Date.now();
+  options.timestamp = options.timestamp || Math.round(Date.now()/1000);
   // Generating SVG font and saving her
   inStream = svgicons2svgfont(options);
   // Generating TTF font and saving her


### PR DESCRIPTION
Wondering if we can pass through the options object to `gulp-svg2ttf`

I found that `svg2ttf` was receiving only `clone` and `timestamp` options.