### PR TITLE
Drop dependency on gulp-util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4121,14 +4121,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4163,6 +4155,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
       "integrity": "sha1-aybpvTr8qnvjtCabUm3huCAArHg="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "gulp-ttf2eot": "^1.1.1",
     "gulp-ttf2woff": "^1.1.0",
     "gulp-ttf2woff2": "^2.0.2",
-    "gulp-util": "^3.0.7",
     "plexer": "^1.0.1",
     "streamfilter": "^1.0.5"
   },


### PR DESCRIPTION
Hello maintainers.

This closes https://github.com/nfroidure/gulp-iconfont/issues/157

Thanks.