### PR TITLE
Run CI on Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 
+dist: trusty
+
 node_js:
   - 6
   - 8


### PR DESCRIPTION
Travis switched to a newer Ubuntu (https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) and build started to fail (https://travis-ci.org/nfroidure/gulp-iconfont/builds/545353614).

Going back to the working environment until we find a way to pass the build on the default OS.